### PR TITLE
fix dir list for html and json

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -218,6 +218,7 @@ static ssize_t
 dir_read_html(void *cls, uint64_t pos, char *buf, size_t max) {
   dir_read_sm_t* sm = (dir_read_sm_t*)cls;
   struct dirent *entry;
+  size_t len = strlen(sm->props.path);
 
   if(max < 512) {
     return 0;
@@ -247,8 +248,9 @@ dir_read_html(void *cls, uint64_t pos, char *buf, size_t max) {
       return 0;
     }
 
-    return snprintf(buf, max, "<li><a href=\"/fs%s/%s\">%s</a></li>",
-		    sm->props.path, entry->d_name, entry->d_name);
+    return snprintf(buf, max, "<li><a href=\"/fs%s%s%s\">%s</a></li>",
+		    sm->props.path, (sm->props.path[len - 1] == '/') ? "" : "/",
+            entry->d_name, entry->d_name);
 
   case DIR_READ_TAIL:
     sm->state = DIR_READ_NULL;


### PR DESCRIPTION
Current code does not work well with dir browser.
The http path could be with or without `/` at path end, the default is without.
I.E. /data/ has dira and dirb
when visit http://127.0.0.1:8080/fs/data
the `dira` href is linked to http://127.0.0.1:8080/fs/dira, because the base link has no `/` at path end.
The changes care both cases, and always make absolue link.
The changes also avoid adding double `/` to the path.