### PR TITLE
correctly notify ip address

### DIFF
--- a/src/ps5/sys.c
+++ b/src/ps5/sys.c
@@ -395,8 +395,18 @@ sys_notify_address(const char* prefix, int port) {
       continue;
     }
 
+    // skip localhost
+    if(!strncmp("lo", ifa->ifa_name, 2)) {
+      continue;
+    }
+
     struct sockaddr_in *in = (struct sockaddr_in*)ifa->ifa_addr;
     inet_ntop(AF_INET, &(in->sin_addr), ip, sizeof(ip));
+
+    // skip interfaces without an ip
+    if(!strncmp("0.", ip, 2)) {
+      continue;
+    }
   }
 
   freeifaddrs(ifaddr);


### PR DESCRIPTION
Currently 127.0.0.1 is shown.
Code is copied from ftpsrv.